### PR TITLE
feat: add route sharing via url and qr

### DIFF
--- a/app/share/route.ts
+++ b/app/share/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const url = searchParams.get('url');
+  if (!url) {
+    return NextResponse.json({ error: 'url is required' }, { status: 400 });
+  }
+  const qrUrl = `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(url)}`;
+  return NextResponse.json({ url, qrUrl });
+}

--- a/app/trips/[id]/share/page.tsx
+++ b/app/trips/[id]/share/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+
+export default function TripSharePage({ params }: { params: { id: string } }) {
+  const [shareUrl, setShareUrl] = useState("");
+  const [qrUrl, setQrUrl] = useState("");
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const url = `${window.location.origin}/trips/${params.id}`;
+    setShareUrl(url);
+    const fetchQr = async () => {
+      try {
+        const res = await fetch(`/share?url=${encodeURIComponent(url)}`);
+        if (res.ok) {
+          const data = await res.json();
+          setQrUrl(data.qrUrl as string);
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    fetchQr();
+  }, [params.id]);
+
+  const handleCopy = async () => {
+    if (!shareUrl) return;
+    await navigator.clipboard.writeText(shareUrl);
+    alert("URLをコピーしました");
+  };
+
+  return (
+    <div className="p-4 flex flex-col items-center gap-4">
+      <div className="w-full max-w-md flex gap-2">
+        <input className="flex-1 border p-2 rounded" value={shareUrl} readOnly />
+        <Button onClick={handleCopy}>コピー</Button>
+      </div>
+      {qrUrl && (
+        <Image
+          src={qrUrl}
+          alt="QR code"
+          width={192}
+          height={192}
+          className="h-48 w-48"
+          unoptimized
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `/share` API that returns share URL and QR-code image link
- add trip share page showing share URL with copy and QR code

## Testing
- `bun run lint` (fails: 71 problems, mostly no-explicit-any)
- `bun run build` (fails: Can't resolve 'tw-animate-css' and other modules)


------
https://chatgpt.com/codex/tasks/task_e_68bda42a07fc832dbffa34316c134925